### PR TITLE
Updates for mac compatability

### DIFF
--- a/torIPChangerScript.py
+++ b/torIPChangerScript.py
@@ -51,6 +51,8 @@ CookieAuthentication 0
         subprocess.run(["brew", "services", "restart", "tor"])
     time.sleep(3)
 
+    print("[+] Tor configured and (re)started.")
+
 def is_port_in_use(port):
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         return s.connect_ex(("127.0.0.1", port)) == 0

--- a/torIPChangerScript.py
+++ b/torIPChangerScript.py
@@ -42,12 +42,14 @@ CookieAuthentication 0
 
     # Try restarting Tor (WSL may not support systemctl)
     if shutil.which("systemctl"):
+        # Linux path
         subprocess.run(["sudo", "systemctl", "restart", "tor"])
-    else:
+    elif shutil.which("service"):
         subprocess.run(["sudo", "service", "tor", "restart"])
+    else:
+        # macOS / Homebrew path
+        subprocess.run(["brew", "services", "restart", "tor"])
     time.sleep(3)
-
-    print("[+] Tor configured and (re)started.")
 
 def is_port_in_use(port):
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:


### PR DESCRIPTION
On Mac, 'systemctl' and 'service' are not used. Instead 'brew services' must be used.